### PR TITLE
Update GenomeSimulation.py to enable simulation of genomes with custom starting sequences (using root_genome=)

### DIFF
--- a/src/asymmetree/genome/GenomeSimulation.py
+++ b/src/asymmetree/genome/GenomeSimulation.py
@@ -150,7 +150,7 @@ class GenomeSimulator:
             self.sequence_dicts = []
         
         if root_genome:
-            if len(root_genome) != len(self.number_of_families):
+            if len(root_genome) != self.number_of_families:
                 raise ValueError('no. of sequences in root genome does not'\
                                  'match no of gene families')
         else:


### PR DESCRIPTION
Fix `TypeError` in `GenomeSimulation.py` where the function tries to take the length of the `number_of_families` attribute, which is an integer (rather than a collection, as it was probably intended).

After this change, `simulate_sequences` works as intended with custom sequences.