### PR TITLE
Fix conflation between `dupl_rate` and `base_rate` when simulating gene trees

### DIFF
--- a/src/asymmetree/treeevolve/RateHeterogeneity.py
+++ b/src/asymmetree/treeevolve/RateHeterogeneity.py
@@ -68,7 +68,7 @@ def gene_trees(S,
     dupl_rate_sampler = Sampler(dupl_rate)
     loss_rate_sampler = Sampler(loss_rate)
     hgt_rate_sampler = Sampler(hgt_rate)
-    base_rate_sampler = Sampler(dupl_rate)
+    base_rate_sampler = Sampler(base_rate)
     
     # autocorrelation between genes of the same or related species
     autocorr_variance = kwargs.pop('autocorr_variance', 0.0)


### PR DESCRIPTION
This commit fixes a bug where the `dupl_rate` is used as the base rate for the simulation of gene trees and the argument `base_rate` is ignored.

The fix enables making simulations with `dupl_rate = 0.0`. Trees generated with the current implementation look like this:

![image](https://github.com/david-schaller/AsymmeTree/assets/37163025/98b5a03c-24c0-4d89-a0ab-626564e2588c)

Whereas with the fix they look like this:

![image](https://github.com/david-schaller/AsymmeTree/assets/37163025/15c4c60f-ebbe-4c07-8216-3353e9e9c87d)



